### PR TITLE
Add catalog-info.yaml config file

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: software-templates
+  annotations:
+    github.com/project-slug: BoxingBox/software-templates
+spec:
+  type: other
+  lifecycle: unknown
+  owner: BoxingBox


### PR DESCRIPTION
This pull request adds a **Backstage entity metadata file** to this repository so that the component can be added to the [Scaffolded Backstage App software catalog](http://localhost:3000).

After this pull request is merged, the component will become available.

For more information, read an [overview of the Backstage software catalog](https://backstage.io/docs/features/software-catalog/).